### PR TITLE
Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ All recent changes are copyright © 2019 Martin Holst Swende.
 $ go get github.com/holiman/bloomfilter
 ```
 
-
 # Face-meltingly fast, thread-safe, marshalable, unionable, probability- and optimal-size-calculating Bloom filter in go
 
 Copyright © 2014-2016,2018 Barry Allard

--- a/bloomfilter.go
+++ b/bloomfilter.go
@@ -82,6 +82,22 @@ func (f *Filter) Contains(v hash.Hash64) bool {
 	return uint64ToBool(r)
 }
 
+// ContainsHash tests if f contains the (already hashed) key
+// Identical to Contains but slightly faster
+func (f *Filter) ContainsHash(hash uint64) bool {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	var (
+		i uint64
+		r = uint64(1)
+	)
+	for n := 0; n < len(f.keys); n++ {
+		i = (hash ^ f.keys[n]) % f.m
+		r &= (f.bits[i>>6] >> uint(i&0x3f)) & 1
+	}
+	return uint64ToBool(r)
+}
+
 // Copy f to a new Bloom filter
 func (f *Filter) Copy() (*Filter, error) {
 	f.lock.RLock()

--- a/bloomfilter.go
+++ b/bloomfilter.go
@@ -75,7 +75,7 @@ func (f *Filter) Contains(v hash.Hash64) bool {
 		i    uint64
 		r    = uint64(1)
 	)
-	for n := 0; n < len(f.keys); n++ {
+	for n := 0; n < len(f.keys) && r != 0; n++ {
 		i = (hash ^ f.keys[n]) % f.m
 		r &= (f.bits[i>>6] >> uint(i&0x3f)) & 1
 	}
@@ -91,7 +91,7 @@ func (f *Filter) ContainsHash(hash uint64) bool {
 		i uint64
 		r = uint64(1)
 	)
-	for n := 0; n < len(f.keys); n++ {
+	for n := 0; n < len(f.keys) && r != 0; n++ {
 		i = (hash ^ f.keys[n]) % f.m
 		r &= (f.bits[i>>6] >> uint(i&0x3f)) & 1
 	}


### PR DESCRIPTION
Make stuff better
```
name                                    old time/op  new time/op  delta
Contains1kX10kX5/contains-6              113ns ± 2%    90ns ± 1%  -20.16%  (p=0.000 n=9+8)
Contains1kX10kX5/containsHash-6         95.0ns ± 1%  75.8ns ± 2%  -20.26%  (p=0.000 n=9+9)
Contains100kX10BX20/contains-6          1.01µs ± 8%  0.17µs ± 1%  -82.75%  (p=0.000 n=9+9)
Contains100kX10BX20/containshash-6       969ns ± 1%   144ns ± 0%  -85.14%  (p=0.000 n=8+8)
Contains94percentMisses/contains-6       258ns ± 2%    91ns ± 1%  -64.79%  (p=0.000 n=9+8)
Contains94percentMisses/containsHash-6   238ns ± 2%    70ns ± 1%  -70.76%  (p=0.000 n=9+9)
```