### PR TITLE
all: less memory use on write to disk

### DIFF
--- a/fileio.go
+++ b/fileio.go
@@ -80,12 +80,7 @@ func (f *Filter) WriteTo(w io.Writer) (n int64, err error) {
 		err = rawW.Close()
 	}()
 
-	content, err := f.MarshalBinary()
-	if err != nil {
-		return -1, err
-	}
-
-	intN, err := rawW.Write(content)
+	intN, _, err := f.MarshallToWriter(rawW)
 	n = int64(intN)
 	return n, err
 }

--- a/fileio_test.go
+++ b/fileio_test.go
@@ -12,6 +12,10 @@ package bloomfilter
 
 import (
 	"bytes"
+	"crypto/sha512"
+	"fmt"
+	"math/rand"
+	"runtime"
 	"testing"
 )
 
@@ -36,5 +40,85 @@ func TestWriteRead(t *testing.T) {
 
 	if !f2.Contains(v) {
 		t.Error("Filters not equal")
+	}
+}
+
+func bToMb(b uint64) uint64 {
+	return b / 1024 / 1024
+}
+func PrintMemUsage() {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	// For info on each, see: https://golang.org/pkg/runtime/#MemStats
+	fmt.Printf("Alloc = %v MiB", bToMb(m.Alloc))
+	fmt.Printf("\tTotalAlloc = %v MiB", bToMb(m.TotalAlloc))
+	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))
+	fmt.Printf("\tNumGC = %v\n", m.NumGC)
+}
+
+func totAllocMb() uint64 {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return bToMb(m.TotalAlloc)
+}
+
+type devnull struct{}
+func (d devnull) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func TestWrite(t *testing.T) {
+	// 1Mb
+	f, _ := New(4*8*1024*1024, 1)
+	fmt.Printf("Allocated 1mb filter\n")
+	PrintMemUsage()
+	_, _ = f.WriteTo(devnull{})
+	fmt.Printf("Wrote filter to devnull\n")
+	PrintMemUsage()
+}
+
+// fillRandom fills the filter with N random values, where N is roughly half
+// the size of the number of uint64's in the filter
+func fillRandom(f *Filter) {
+	num := len(f.bits) * 4
+	for i := 0; i < num; i++ {
+		f.AddHash(uint64(rand.Int63()))
+	}
+}
+
+// TestMarshaller tests that it writes outputs correctly.
+func TestMarshaller(t *testing.T) {
+
+	h1 := sha512.New384()
+	h2 := sha512.New384()
+
+	f, _ := New(1*8*1024*1024, 1)
+	fillRandom(f)
+	// Marshall using writer
+	f.MarshallToWriter(h1)
+	// Marshall as a blob
+	data, _ := f.MarshalBinary()
+	h2.Write(data)
+
+	if have, want := h1.Sum(nil), h2.Sum(nil); !bytes.Equal(have, want) {
+		t.Errorf("Marshalling error, have %x want %x", have, want)
+	}
+}
+
+func BenchmarkWrite1Mb(b *testing.B) {
+
+	// 1Mb
+	f, _ := New(1*8*1024*1024, 1)
+	f.Add(hashableUint64(0))
+	f.Add(hashableUint64(1))
+	f.Add(hashableUint64(1 << 3))
+	f.Add(hashableUint64(1 << 40))
+	f.Add(hashableUint64(1 << 23))
+	f.Add(hashableUint64(1 << 16))
+	f.Add(hashableUint64(1 << 28))
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = f.WriteTo(devnull{})
 	}
 }

--- a/textmarshaler.go
+++ b/textmarshaler.go
@@ -34,7 +34,7 @@ func (f *Filter) MarshalText() (text []byte, err error) {
 		s += fmt.Sprintf(bitsFormat, w) + nl()
 	}
 
-	_, hash, err := f.marshal()
+	_, hash, err := f.MarshallToWriter(devnull{})
 	if err != nil {
 		return nil, err
 	}

--- a/textunmarshaler.go
+++ b/textunmarshaler.go
@@ -78,7 +78,7 @@ func unmarshalAndCheckTextHash(r io.Reader, f *Filter) (err error) {
 		}
 	}
 
-	_, expectedHash, err := f.marshal()
+	_, expectedHash, err := f.MarshallToWriter(devnull{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR makes the filter less likely to cause OOM when saving to disk. Previously, there was a 3x amplification when storing to disk, meaning that in order to save a `2Gb` bloom filter, an additional `4G` was used by the implementation. 
It also called `bytes` on the buffer, to shove into hashing, which caused another full alloc. 
Internally, it also used `binary.Write` with the full `bits`, which also allocated a same-size buffer (although that was short-lived, and could be gc:ed by the time the hashing was done). 

This PR makes it so we only writes in chunks of `20%`, and write directly to hasher/file instead of buffering in memory. 

```
name        old time/op    new time/op    delta
Write1Mb-6    3.96ms ±21%    5.85ms ± 1%   +47.85%  (p=0.008 n=5+5)

name        old alloc/op   new alloc/op   delta
Write1Mb-6    2.11MB ± 0%    0.88MB ± 0%   -58.41%  (p=0.008 n=5+5)

name        old allocs/op  new allocs/op  delta
Write1Mb-6      18.0 ± 0%      36.0 ± 0%  +100.00%  (p=0.008 n=5+5)
```
it's a bit smaller (for small filters), and does more `allocs` due to the chunking, but the actual bytes allocated are a lot smaller. 