### PR TITLE
all: update license info

### DIFF
--- a/v2/MIT-LICENSE.txt
+++ b/v2/MIT-LICENSE.txt
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright © 2014, 2015 Barry Allard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/v2/binarymarshaler.go
+++ b/v2/binarymarshaler.go
@@ -2,12 +2,17 @@
 // marshalable, unionable, probability- and
 // optimal-size-calculating Bloom filter in go
 //
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
 // https://github.com/steakknife/bloomfilter
 //
 // Copyright © 2014, 2015, 2018 Barry Allard
+// Copyright © 2020 Martin Holst Swende
 //
 // MIT license
 //
+
 package v2
 
 import (

--- a/v2/binaryunmarshaler.go
+++ b/v2/binaryunmarshaler.go
@@ -2,12 +2,17 @@
 // marshalable, unionable, probability- and
 // optimal-size-calculating Bloom filter in go
 //
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
 // https://github.com/steakknife/bloomfilter
 //
 // Copyright © 2014, 2015, 2018 Barry Allard
+// Copyright © 2020 Martin Holst Swende
 //
 // MIT license
 //
+
 package v2
 
 import (

--- a/v2/bloomfilter.go
+++ b/v2/bloomfilter.go
@@ -2,13 +2,16 @@
 // marshalable, unionable, probability- and
 // optimal-size-calculating Bloom filter in go
 //
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
 // https://github.com/steakknife/bloomfilter
 //
 // Copyright © 2014, 2015, 2018 Barry Allard
+// Copyright © 2020 Martin Holst Swende
 //
 // MIT license
 //
-// Copyright © 2020 Martin Holst Swende, continued on the work of Barry Allard
 
 package v2
 

--- a/v2/bloomfilter_test.go
+++ b/v2/bloomfilter_test.go
@@ -2,12 +2,17 @@
 // marshalable, unionable, probability- and
 // optimal-size-calculating Bloom filter in go
 //
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
 // https://github.com/steakknife/bloomfilter
 //
 // Copyright © 2014, 2015, 2018 Barry Allard
+// Copyright © 2020 Martin Holst Swende
 //
 // MIT license
 //
+
 package v2
 
 import (

--- a/v2/conformance.go
+++ b/v2/conformance.go
@@ -2,12 +2,17 @@
 // marshalable, unionable, probability- and
 // optimal-size-calculating Bloom filter in go
 //
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
 // https://github.com/steakknife/bloomfilter
 //
 // Copyright © 2014, 2015, 2018 Barry Allard
+// Copyright © 2020 Martin Holst Swende
 //
 // MIT license
 //
+
 package v2
 
 import (

--- a/v2/fileio.go
+++ b/v2/fileio.go
@@ -2,12 +2,17 @@
 // marshalable, unionable, probability- and
 // optimal-size-calculating Bloom filter in go
 //
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
 // https://github.com/steakknife/bloomfilter
 //
 // Copyright © 2014, 2015, 2018 Barry Allard
+// Copyright © 2020 Martin Holst Swende
 //
 // MIT license
 //
+
 package v2
 
 import (

--- a/v2/fileio_test.go
+++ b/v2/fileio_test.go
@@ -2,12 +2,17 @@
 // marshalable, unionable, probability- and
 // optimal-size-calculating Bloom filter in go
 //
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
 // https://github.com/steakknife/bloomfilter
 //
 // Copyright © 2014, 2015, 2018 Barry Allard
-// Copyright © 2018, 2020 Martin Holst Swende
+// Copyright © 2020 Martin Holst Swende
+//
 // MIT license
 //
+
 package v2
 
 import (

--- a/v2/iscompatible.go
+++ b/v2/iscompatible.go
@@ -2,12 +2,17 @@
 // marshalable, unionable, probability- and
 // optimal-size-calculating Bloom filter in go
 //
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
 // https://github.com/steakknife/bloomfilter
 //
 // Copyright © 2014, 2015, 2018 Barry Allard
+// Copyright © 2020 Martin Holst Swende
 //
 // MIT license
 //
+
 package v2
 
 // returns 0 if equal, does not compare len(b0) with len(b1)

--- a/v2/new.go
+++ b/v2/new.go
@@ -2,12 +2,17 @@
 // marshalable, unionable, probability- and
 // optimal-size-calculating Bloom filter in go
 //
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
 // https://github.com/steakknife/bloomfilter
 //
 // Copyright © 2014, 2015, 2018 Barry Allard
+// Copyright © 2020 Martin Holst Swende
 //
 // MIT license
 //
+
 package v2
 
 import (

--- a/v2/optimal_test.go
+++ b/v2/optimal_test.go
@@ -1,3 +1,18 @@
+// Package bloomfilter is face-meltingly fast, thread-safe,
+// marshalable, unionable, probability- and
+// optimal-size-calculating Bloom filter in go
+//
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
+// https://github.com/steakknife/bloomfilter
+//
+// Copyright © 2014, 2015, 2018 Barry Allard
+// Copyright © 2020 Martin Holst Swende
+//
+// MIT license
+//
+
 package v2
 
 import (

--- a/v2/statistics.go
+++ b/v2/statistics.go
@@ -2,12 +2,17 @@
 // marshalable, unionable, probability- and
 // optimal-size-calculating Bloom filter in go
 //
+// https://github.com/holiman/bloomfilter
+//
+// Original source:
 // https://github.com/steakknife/bloomfilter
 //
 // Copyright © 2014, 2015, 2018 Barry Allard
+// Copyright © 2020 Martin Holst Swende
 //
 // MIT license
 //
+
 package v2
 
 import (


### PR DESCRIPTION
This PR updates the license info 
- so it's properly parsed by go doc, for the v2 package
- adds empty line before package declaration, to avoid the license becoming part of the package documentation