### PR TITLE
Clear + improved locking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,21 +6,19 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.14
+      - image: cimg/go:1.19
 
-    working_directory: /go/src/github.com/holiman/bloomfilter
     steps:
       - checkout
 
       # specify any bash command here prefixed with `run: `
-      - run: go get -v -t -d ./...
       - run: (cd v2 && go test -v ./... -coverprofile=coverage.txt -covermode=count )
       - run:
           name: "Codecov upload"
           command: bash <(curl -s https://codecov.io/bash)
       - run:
           name: "Install tools"
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
       - run:
           name: "Lint"
           command: (cd v2 && golangci-lint run)

--- a/v2/bloomfilter.go
+++ b/v2/bloomfilter.go
@@ -146,3 +146,14 @@ func (f *Filter) Union(f2 *Filter) (out *Filter, err error) {
 	out.n = f.n + f2.n
 	return out, nil
 }
+
+// Clear clears the bloom filter.
+func (f *Filter) Clear() {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	for i, bitword := range f.bits {
+		f.bits[i] = 0
+	}
+	f.n = 0 // Also update the counters
+}

--- a/v2/bloomfilter.go
+++ b/v2/bloomfilter.go
@@ -27,10 +27,11 @@ var (
 
 // Filter is an opaque Bloom filter type
 type Filter struct {
-	lock sync.RWMutex
-	bits []uint64
 	keys []uint64
 	m    uint64 // number of bits the "bits" field should recognize
+
+	lock sync.RWMutex // lock guards accesses to the fields below
+	bits []uint64
 	n    uint64 // number of inserted elements
 }
 

--- a/v2/bloomfilter.go
+++ b/v2/bloomfilter.go
@@ -111,13 +111,16 @@ func (f *Filter) Copy() (*Filter, error) {
 
 // UnionInPlace merges Bloom filter f2 into f
 func (f *Filter) UnionInPlace(f2 *Filter) error {
+	if f == f2 {
+		return nil
+	}
 	if !f.IsCompatible(f2) {
 		return errors.New("incompatible bloom filters")
 	}
-
 	f.lock.Lock()
 	defer f.lock.Unlock()
-
+	f2.lock.RLock()
+	defer f2.lock.RUnlock()
 	for i, bitword := range f2.bits {
 		f.bits[i] |= bitword
 	}
@@ -128,10 +131,12 @@ func (f *Filter) UnionInPlace(f2 *Filter) error {
 
 // Union merges f2 and f2 into a new Filter out
 func (f *Filter) Union(f2 *Filter) (out *Filter, err error) {
+	if f == f2 {
+		return f.Copy()
+	}
 	if !f.IsCompatible(f2) {
 		return nil, errors.New("incompatible bloom filters")
 	}
-
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 
@@ -139,6 +144,9 @@ func (f *Filter) Union(f2 *Filter) (out *Filter, err error) {
 	if err != nil {
 		return nil, err
 	}
+	f2.lock.RLock()
+	defer f2.lock.RUnlock()
+
 	for i, bitword := range f2.bits {
 		out.bits[i] = f.bits[i] | bitword
 	}
@@ -152,7 +160,7 @@ func (f *Filter) Clear() {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	for i, bitword := range f.bits {
+	for i := range f.bits {
 		f.bits[i] = 0
 	}
 	f.n = 0 // Also update the counters

--- a/v2/fileio.go
+++ b/v2/fileio.go
@@ -68,14 +68,10 @@ func ReadFile(filename string) (f *Filter, n int64, err error) {
 
 // WriteTo a Writer w from lossless-compressed Bloom Filter f
 func (f *Filter) WriteTo(w io.Writer) (n int64, err error) {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
-
 	rawW := gzip.NewWriter(w)
 	defer rawW.Close()
 
 	intN, _, err := f.MarshallToWriter(rawW)
-	//intN, _, err := f.MarshallToWriter(w)
 	n = int64(intN)
 	return n, err
 }

--- a/v2/iscompatible.go
+++ b/v2/iscompatible.go
@@ -26,12 +26,6 @@ func noBranchCompareUint64s(b0, b1 []uint64) uint64 {
 
 // IsCompatible is true if f and f2 can be Union()ed together
 func (f *Filter) IsCompatible(f2 *Filter) bool {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
-
-	f2.lock.RLock()
-	defer f2.lock.RUnlock()
-
 	// 0 is true, non-0 is false
 	compat := f.M() ^ f2.M()
 	compat |= f.K() ^ f2.K()


### PR DESCRIPTION
This PR adds the method `Clear()` to bloom filter. 

Additonally, it fixes an earlier flaw in the locking, when a union was made, the filter needs to not only lock the filter being written to, but also the filter being read from. When doing so, we also need to be careful about the case when both arguments are the same: otherwise we wind up in a deadlock. 